### PR TITLE
Added support to utf-8 encoded unicode

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -707,6 +707,9 @@ python_to_avro(ConvertInfo *info, PyObject *pyobj, avro_value_t *dest)
         {
             char *buf;
             Py_ssize_t len;
+            if (PyUnicode_Check(pyobj)) {
+                pyobj = PyUnicode_AsUTF8String(pyobj);
+            }
             if (PyString_AsStringAndSize(pyobj, &buf, &len) < 0) {
                 return set_type_error(EINVAL, pyobj);
             }

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #!/usr/bin/env python
 
 # Copyright 2015 CRS4
@@ -94,3 +95,17 @@ def test_unicode_map_keys():
     serializer = pyavroc.AvroSerializer(schema)
     rec_bytes = serializer.serialize({"bar": {"k": "v"}})
     assert serializer.serialize({"bar": {u"k": "v"}}) == rec_bytes
+
+
+def test_serialize_utf8_string():
+    schema = '["string"]'
+    serializer = pyavroc.AvroSerializer(schema)
+    deserializer = Deserializer(schema)
+
+    datum = "barà"
+    rec_bytes = serializer.serialize(datum)
+    assert deserializer.deserialize(rec_bytes) == unicode(datum, "utf-8")
+
+    datum = u"barà"
+    rec_bytes = serializer.serialize(datum)
+    assert deserializer.deserialize(rec_bytes) == datum


### PR DESCRIPTION
I corrected a little bug that caused an error serializing a unicode object with utf-8 characters.

Consider the following code:

``` python
schema = '["string"]'
serializer = pyavroc.AvroSerializer(schema)
serializer.serialize(u"barà")
```

Before the correction it would have raised a `TypeError: function takes exactly 5 arguments (1 given)`. It failed because `PyString_AsStringAndSize` returned -1. 
Now `unicode` objects are converted in UTF-8 strings before getting serialized. 
